### PR TITLE
fix: update url for documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ SEE ALSO:
 
 DOCUMENTATION:
 
-* https://behave.github.com/behave.example (latest version)
+* https://behave.github.io/behave.example (latest version)
 
 REPOSITORIES:
 


### PR DESCRIPTION
Subdomains of github.com are deprecated for GitHub Pages. Use github.io instead.